### PR TITLE
Add custom completions

### DIFF
--- a/lib/igitsh/completer.rb
+++ b/lib/igitsh/completer.rb
@@ -69,6 +69,8 @@ module Igitsh
     private_class_method :for_option
 
     # @param zipper [Igitsh::TokenZipper]
+    #
+    # @return [Array<String>, nil]
     def self.for_filepath(zipper:)
       return if zipper.trailing_whitespace?
       return unless zipper.last.string_token?

--- a/lib/igitsh/completer.rb
+++ b/lib/igitsh/completer.rb
@@ -123,11 +123,11 @@ module Igitsh
           else
             Git.unstaged_files(prefix:, limit: MAX_COMPLETIONS)
           end
-        else
-          []
+        when "log", "revert", "reset"
+          Git.commits(limit: MAX_COMPLETIONS) if zipper.trailing_whitespace?
         end
 
-      completions unless completions.empty?
+      completions unless completions.nil? || completions.empty?
     end
     private_class_method :custom_completions_for
   end

--- a/lib/igitsh/git.rb
+++ b/lib/igitsh/git.rb
@@ -150,6 +150,25 @@ module Igitsh
       last_stdout&.close
     end
 
+    # @param limit [Integer]
+    #
+    # @return [Array<String>]
+    def self.commits(limit:)
+      command = Shellwords.join(["git", "rev-list", "--all", "--oneline", "--max-count", limit])
+      output = `#{command}`
+      @commit_hash_to_title = output
+        .each_line(chomp: true)
+        .to_h { |line| line.split(" ", 2) }
+      @commit_hash_to_title.keys
+    end
+
+    # Note: This is loaded by the `.commits` method so that it can be reused for hints.
+    #
+    # @return [Hash<String, String>]
+    def self.commit_hash_to_title
+      @commit_hash_to_title || {}
+    end
+
     Aliases = Struct.new(:local, :global, keyword_init: true) do
       # @param key [String]
       #

--- a/lib/igitsh/git.rb
+++ b/lib/igitsh/git.rb
@@ -78,6 +78,11 @@ module Igitsh
     end
 
     # @return [Array<String>]
+    def self.staged_files
+      `git diff --name-only --staged`.lines(chomp: true)
+    end
+
+    # @return [Array<String>]
     def self.unstaged_files
       `git ls-files -z --modified --others --exclude-standard`.split("\0")
     end

--- a/lib/igitsh/git.rb
+++ b/lib/igitsh/git.rb
@@ -77,6 +77,18 @@ module Igitsh
       ).freeze
     end
 
+    # @return [Array<String>]
+    def self.unstaged_files
+      `git ls-files -z --modified --others --exclude-standard`.split("\0")
+    end
+
+    # @return [Array<String>]
+    def self.other_branch_names
+      `git branch --sort=-committerdate`
+        .lines(chomp: true)
+        .filter_map { |line| line.strip unless line.start_with?("*") }
+    end
+
     Aliases = Struct.new(:local, :global, keyword_init: true) do
       # @param key [String]
       #

--- a/lib/igitsh/hinter.rb
+++ b/lib/igitsh/hinter.rb
@@ -67,11 +67,10 @@ module Igitsh
     #
     # @return [Array<String>] formatted lines
     def self.from_completion(completion, width:)
-      description = if Git.command_descriptions.include?(completion)
-        Git.command_descriptions.fetch(completion)
-      elsif Commander.internal_command_names.include?(completion)
-        Commander.name_to_internal_command.fetch(completion).description
-      end
+      description =
+        Git.command_descriptions[completion] ||
+        Commander.name_to_internal_command[completion]&.description ||
+        Git.commit_hash_to_title[completion]
 
       if description
         Stringer.wrap_ascii_paragraph(description, width: width, indent: 2)

--- a/lib/igitsh/token_zipper.rb
+++ b/lib/igitsh/token_zipper.rb
@@ -42,14 +42,21 @@ module Igitsh
     #
     # @return [Integer]
     def size
-      @tokens.size
+      tokens.size
     end
 
     # Returns true if there are no tokens.
     #
     # @return [Boolean]
     def empty?
-      @tokens.empty?
+      tokens.empty?
+    end
+
+    # Returns true if there is trailing whitespace after the last token.
+    #
+    # @return [Boolean]
+    def trailing_whitespace?
+      (last.token&.end_position || 0) < source.size
     end
 
     # Yields zippers representing each token starting from the beginning.
@@ -97,9 +104,9 @@ module Igitsh
         self
       else
         self.class.new(
-          source: @source,
-          tokens: @tokens,
-          index: @index - 1,
+          source:,
+          tokens:,
+          index: index - 1,
           after: self,
           first: @first,
           last: @last
@@ -113,9 +120,9 @@ module Igitsh
         self
       else
         self.class.new(
-          source: @source,
-          tokens: @tokens,
-          index: @index + 1,
+          source:,
+          tokens:,
+          index: index + 1,
           before: self,
           first: @first,
           last: @last
@@ -201,7 +208,7 @@ module Igitsh
     #
     # @return [Igitsh::Token::Base, nil]
     def token
-      @tokens[@index] unless head? || tail?
+      tokens[index] unless head? || tail?
     end
 
     # Returns true if the current token is a string.

--- a/lib/igitsh/token_zipper.rb
+++ b/lib/igitsh/token_zipper.rb
@@ -302,7 +302,7 @@ module Igitsh
 
     # Returns the most recent command if one exists before an action or head.
     #
-    # @return [Igitsh::TokenZipper]
+    # @return [Igitsh::TokenZipper, nil]
     def current_command
       return @current_command if defined?(@current_command)
 

--- a/spec/gitsh/completer_spec.rb
+++ b/spec/gitsh/completer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Igitsh::Completer, :without_git do
 
       it "returns no results when prefix doesn't match" do
         ["smile", "add README.md && smile"].each do |line|
-          expect(described_class.from_line(line)).to be_empty
+          expect(described_class.from_line(line)).to be_nil
         end
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe Igitsh::Completer, :without_git do
 
         it "returns no results when the prefix doesn't match" do
           ["diff --input", "restore README.md; diff --input"].each do |line|
-            expect(described_class.from_line(line)).to be_empty
+            expect(described_class.from_line(line)).to be_nil
           end
         end
       end

--- a/spec/gitsh/git_spec.rb
+++ b/spec/gitsh/git_spec.rb
@@ -15,13 +15,49 @@ RSpec.describe Igitsh::Git do
 
   describe ".current_branch" do
     it "returns a branch name" do
-      expect(described_class.current_branch).to be_a(String)
+      branch_name = described_class.current_branch
+      expect(branch_name).to be_a(String)
+      expect(branch_name).not_to be_empty
     end
   end
 
   describe ".uncommitted_changes" do
     it "returns a Changes struct" do
       expect(described_class.uncommitted_changes).to be_a(described_class::Changes)
+    end
+  end
+
+  RSpec.shared_context "uncommitted changes", :in_git_repo do
+    before do
+      FileUtils.touch(%w[staged_1.rb staged_2.rb unstaged_1.rb unstaged_2.rb])
+      Igitsh::Test.quiet_system("git add staged_1.rb staged_2.rb")
+    end
+  end
+
+  describe ".staged_files" do
+    include_context "uncommitted changes"
+
+    it "lists staged files" do
+      expect(described_class.staged_files).to eq(%w[staged_1.rb staged_2.rb])
+    end
+  end
+
+  describe ".unstaged_files" do
+    include_context "uncommitted changes"
+
+    it "lists unstaged files" do
+      expect(described_class.unstaged_files).to eq(%w[unstaged_1.rb unstaged_2.rb])
+    end
+  end
+
+  describe ".other_branch_names", :in_git_repo do
+    before do
+      Igitsh::Test.quiet_system("git branch -c second")
+      Igitsh::Test.quiet_system("git branch -c first")
+    end
+
+    it "returns the branch name list" do
+      expect(described_class.other_branch_names).to eq(%w[first second])
     end
   end
 

--- a/spec/gitsh/git_spec.rb
+++ b/spec/gitsh/git_spec.rb
@@ -38,7 +38,18 @@ RSpec.describe Igitsh::Git do
     include_context "uncommitted changes"
 
     it "lists staged files" do
-      expect(described_class.staged_files).to eq(%w[staged_1.rb staged_2.rb])
+      expect(described_class.staged_files(prefix: "", limit: 5))
+        .to eq(%w[staged_1.rb staged_2.rb])
+    end
+
+    it "filters staged files by prefix" do
+      expect(described_class.staged_files(prefix: "staged_2", limit: 5))
+        .to eq(%w[staged_2.rb])
+    end
+
+    it "filters staged files by limit" do
+      expect(described_class.staged_files(prefix: "", limit: 1))
+        .to eq(%w[staged_1.rb])
     end
   end
 
@@ -46,7 +57,18 @@ RSpec.describe Igitsh::Git do
     include_context "uncommitted changes"
 
     it "lists unstaged files" do
-      expect(described_class.unstaged_files).to eq(%w[unstaged_1.rb unstaged_2.rb])
+      expect(described_class.unstaged_files(prefix: "", limit: 5))
+        .to eq(%w[unstaged_1.rb unstaged_2.rb])
+    end
+
+    it "filters unstaged files by prefix" do
+      expect(described_class.unstaged_files(prefix: "unstaged_2", limit: 5))
+        .to eq(%w[unstaged_2.rb])
+    end
+
+    it "filters unstaged files by limit" do
+      expect(described_class.unstaged_files(prefix: "", limit: 1))
+        .to eq(%w[unstaged_1.rb])
     end
   end
 
@@ -57,7 +79,18 @@ RSpec.describe Igitsh::Git do
     end
 
     it "returns the branch name list" do
-      expect(described_class.other_branch_names).to eq(%w[first second])
+      expect(described_class.other_branch_names(prefix: "", limit: 5))
+        .to eq(%w[first second])
+    end
+
+    it "filters branch names by prefix" do
+      expect(described_class.other_branch_names(prefix: "sec", limit: 5))
+        .to eq(%w[second])
+    end
+
+    it "filters branch names by limit" do
+      expect(described_class.other_branch_names(prefix: "", limit: 1))
+        .to eq(%w[first])
     end
   end
 

--- a/spec/gitsh/git_spec.rb
+++ b/spec/gitsh/git_spec.rb
@@ -94,6 +94,29 @@ RSpec.describe Igitsh::Git do
     end
   end
 
+  describe ".commits", :in_git_repo do
+    it "it loads commit hashes and titles", :aggregate_failures do
+      expect(described_class.commit_hash_to_title).to be_empty
+
+      commits = described_class.commits(limit: 5)
+      expect(commits.size).to eq(1)
+      expect(described_class.commit_hash_to_title).to eq({
+        commits.fetch(0) => "init"
+      })
+
+      FileUtils.touch(%w[second.rb])
+      Igitsh::Test.quiet_system("git add second.rb")
+      Igitsh::Test.quiet_system("git commit -m 'second'")
+
+      commits = described_class.commits(limit: 5)
+      expect(commits.size).to eq(2)
+      expect(described_class.commit_hash_to_title).to eq({
+        commits.fetch(0) => "second",
+        commits.fetch(1) => "init"
+      })
+    end
+  end
+
   describe ".aliases" do
     it "returns an Aliases struct", :in_git_repo do
       described_class.set_alias(

--- a/spec/gitsh/hinter_spec.rb
+++ b/spec/gitsh/hinter_spec.rb
@@ -4,11 +4,21 @@ require "rainbow"
 
 RSpec.describe Igitsh::Hinter, :without_git do
   describe ".from_completion" do
+    let(:commit_info) do
+      {
+        "01c6912" => "Add commit completions",
+        "6d8285e" => "Avoid filtering when prefix is empty",
+        "14fc0fa" => "Add filepath completions"
+      }
+    end
+    let(:indent) { "  " }
+
     before do
       allow(Igitsh::Git).to receive(:command_names).and_return(%w[diff])
       allow(Igitsh::Git).to receive(:command_set).and_return(Set["diff"])
       allow(Igitsh::Git).to receive(:command_descriptions).and_call_original
       allow(Igitsh::Git).to receive(:raw_command_descriptions).and_call_original
+      allow(Igitsh::Git).to receive(:commit_hash_to_title).and_return(commit_info)
     end
 
     context "with Git command" do
@@ -40,6 +50,20 @@ RSpec.describe Igitsh::Hinter, :without_git do
         end
 
         expect(command_hints).to match_snapshot("internal_command_hints")
+      end
+    end
+
+    context "with commit hash" do
+      it "returns commit title hints", :aggregate_failures do
+        commit_info.each do |hash, title|
+          expect(described_class.from_completion(hash, width: 40)).to eq([indent + title])
+        end
+      end
+    end
+
+    context "without hints" do
+      it "returns no hints" do
+        expect(described_class.from_completion("not_completable", width: 25)).to be_empty
       end
     end
   end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "property testing" do
 
       gen_constants = %w[
         & | ; && || -- ' "
-        push pull commit grep diff :exit :alias
+        add push pull commit merge grep diff log restore :exit :alias
         --no- --stat --max-depth --color=never --local --global --help
       ]
       gen_constants << " " << "  "


### PR DESCRIPTION
This adds some basic unstaged file and branch name completions for the `add`, `restore`, `checkout`, `switch` and `merge` commands.

Todo:
- [x] Support more patterns like `git restore --staged`
- [x] Ignore irrelevant options like `git add -v`
- [x] Add generic file support ~for `git mv` and `git rm`~ using the `./` prefix
- [x] Add commit support for `git log`, `git revert` and `git reset`
- [x] Add specs