### PR TITLE
Make Git.commits test deterministic

### DIFF
--- a/spec/gitsh/git_spec.rb
+++ b/spec/gitsh/git_spec.rb
@@ -96,8 +96,6 @@ RSpec.describe Igitsh::Git do
 
   describe ".commits", :in_git_repo do
     it "it loads commit hashes and titles", :aggregate_failures do
-      expect(described_class.commit_hash_to_title).to be_empty
-
       commits = described_class.commits(limit: 5)
       expect(commits.size).to eq(1)
       expect(described_class.commit_hash_to_title).to eq({


### PR DESCRIPTION
If run in isolation, this test works fine. When run with other tests it is not deterministic because the @commit_hash_to_title instance variable might have already been cached from a previous test. By removing this expectation the rest of the test should be correct since every call to `Git.commits` actually overrides that cached instance variable.